### PR TITLE
Revert "Update to Crane 0.3.1 and migrate existing code"

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -30,7 +30,7 @@ libraryDependencies += "org.skife.com.typesafe.config" % "typesafe-config" % "0.
 
 libraryDependencies += "org.mindrot" % "jbcrypt" % "0.3m"
 
-libraryDependencies += "net.timothyhahn" % "crane_2.10" % "0.3.1"
+libraryDependencies += "net.timothyhahn" % "crane_2.10" % "0.2.7"
 
 libraryDependencies += "com.typesafe.akka" %% "akka-testkit" % "2.2.3" % "test"
 

--- a/src/main/scala/ayai/actions/MoveDirection.scala
+++ b/src/main/scala/ayai/actions/MoveDirection.scala
@@ -18,8 +18,8 @@ class MoveDirection(val xDirection: Int, val yDirection: Int) extends Action {
   ** Take the current velocity and multiplies it by the current xDirection and adds that to the position
   **/
   override def process(e: Entity) {
-    (e.getComponent[Position], e.getComponent[Velocity]) match {
-      case (Some(position), Some(velocity)) => {
+    (e.getComponent(classOf[Position]), e.getComponent(classOf[Velocity])) match {
+      case (Some(position: Position), Some(velocity: Velocity)) => {
         position.x += xDirection * velocity.x
         position.y += yDirection * velocity.y
       }

--- a/src/main/scala/ayai/collisions/QuadTree.scala
+++ b/src/main/scala/ayai/collisions/QuadTree.scala
@@ -44,8 +44,8 @@ class QuadTree(var level: Int, var bounds: Rectangle) {
   private def getIndex(e: Entity): Int = {
     var index  = -1
 
-    (e.getComponent[Position], e.getComponent[Bounds]) match {
-      case(Some(p), Some(bound)) => {
+    (e.getComponent(classOf[Position]), e.getComponent(classOf[Bounds])) match {
+      case(Some(p: Position), Some(bound: Bounds)) => {
         val verticalMidpoint: Double = bounds.x + (bounds.width / 2)
         val horizontalMidpoint: Double = bounds.y + (bounds.height / 2)
 

--- a/src/main/scala/ayai/factories/EntityFactory.scala
+++ b/src/main/scala/ayai/factories/EntityFactory.scala
@@ -346,9 +346,16 @@ object EntityFactory {
     animations += new Animation("facedown", 0, 0)
     lootEntity.components += new SpriteSheet("props", animations, 40, 40)
 
-    lootEntity.components += new Loot(id, initiator.getComponent[Character].map(_.id).getOrElse(""))
+    lootEntity.components += new Loot(id, initiator.getComponent(classOf[Character]) match {
+      case Some(character: Character) => character.id
+      case _ => ""
+    })
 
-    initiator.getComponent[Inventory].foreach(lootEntity.components += _.copy())
+    initiator.getComponent(classOf[Inventory]) match {
+      case (Some(inv: Inventory)) =>
+        lootEntity.components += inv.copy()
+        case _ =>
+    }
     lootEntity.components += position
     lootEntity
   }

--- a/src/main/scala/ayai/factories/GraphFactory.scala
+++ b/src/main/scala/ayai/factories/GraphFactory.scala
@@ -42,13 +42,12 @@ object GraphFactory {
     val entityArray = Array.fill[Node](tileMap.width, tileMap.height) { Node(NORMAL)  }
 
     entities.foreach { entity =>
-      val position = entity.getComponent[Position]
+      val position = entity.getComponent(classOf[Position])
       (position: @unchecked) match {
-        case Some(p) =>
+        case Some(p: Position) =>
           val gridPosition = convertPositionToGrid(p, tileMap.tileSize.toFloat)
-          if (inBounds(gridPosition._1, gridPosition._2)) {
+          if(inBounds(gridPosition._1, gridPosition._2))
             entityArray(gridPosition._1)(gridPosition._2) = Node(IMPASS)
-          }
       }
     }
 

--- a/src/main/scala/ayai/gamestate/GameStateSerializer.scala
+++ b/src/main/scala/ayai/gamestate/GameStateSerializer.scala
@@ -51,17 +51,17 @@ class GameStateSerializer(world: World) extends Actor {
                                                       , classOf[Experience]),
                                                      exclude=List(classOf[NPC], classOf[Dead]))
         val jsonLift: JObject =
-            "players" -> entities.map{ e =>
-             (e.getComponent[Character],
-               e.getComponent[Position],
-               e.getComponent[Health],
-               e.getComponent[Mana],
-               e.getComponent[Actionable],
-               e.getComponent[SpriteSheet],
-               e.getComponent[Experience]) match {
-                 case (Some(character), Some(position), Some(health),
-                       Some(mana), Some(actionable), Some(spritesheet),
-                       Some(experience)) =>
+            ("players" -> entities.map{ e =>
+             (e.getComponent(classOf[Character]),
+               e.getComponent(classOf[Position]),
+               e.getComponent(classOf[Health]),
+               e.getComponent(classOf[Mana]),
+               e.getComponent(classOf[Actionable]),
+               e.getComponent(classOf[SpriteSheet]),
+               e.getComponent(classOf[Experience])) match {
+                 case (Some(character: Character), Some(position: Position), Some(health: Health),
+                       Some(mana: Mana), Some(actionable: Actionable), Some(spritesheet: SpriteSheet),
+                       Some(experience: Experience)) =>
                    ((character.asJson) ~
                    (position.asJson) ~
                    (health.asJson) ~
@@ -72,20 +72,20 @@ class GameStateSerializer(world: World) extends Actor {
                  case _ =>
                    log.warn("f3d3275: getComponent failed to return anything BLARG2")
                    JNothing
-             }}
+             }})
         val npcs = world.getEntitiesWithExclusions(include=List(classOf[Character], classOf[Position],
                                                  classOf[Health], classOf[Mana],
                                                  classOf[NPC], classOf[SpriteSheet]),
                                                   exclude=List(classOf[Dead]))
 
-        npcJSON = "npcs" -> npcs.map { npc =>
-          (npc.getComponent[Character],
-            npc.getComponent[Position],
-            npc.getComponent[Health],
-            npc.getComponent[Mana],
-            npc.getComponent[SpriteSheet]) match {
-              case (Some(character), Some(position),
-                Some(health), Some(mana), Some(spritesheet)) =>
+        npcJSON= ("npcs" -> npcs.map{ npc =>
+          (npc.getComponent(classOf[Character]),
+            npc.getComponent(classOf[Position]),
+            npc.getComponent(classOf[Health]),
+            npc.getComponent(classOf[Mana]),
+            npc.getComponent(classOf[SpriteSheet])) match {
+              case (Some(character: Character), Some(position: Position),
+                Some(health: Health), Some(mana: Mana), Some(spritesheet: SpriteSheet)) =>
                 ((character.asJson) ~
                   (position.asJson) ~
                   (health.asJson) ~
@@ -94,40 +94,41 @@ class GameStateSerializer(world: World) extends Actor {
               case _ =>
                 log.warn("f3d3275: getComponent failed to return anything BLARG2")
                 JNothing
-            }}
+            }})
 
         val loot = world.getEntitiesWithExclusions(include=List(classOf[Loot]))
 
-        lootJSON = "loot" -> loot.map{ l =>
-          (l.getComponent[Position],
-            l.getComponent[SpriteSheet],
-            l.getComponent[Loot]) match {
-              case (Some(position), Some(spritesheet), Some(lo)) => {
+        lootJSON = ("loot" -> loot.map{ l => 
+          (l.getComponent(classOf[Position]),
+            l.getComponent(classOf[SpriteSheet]),
+            l.getComponent(classOf[Loot])) match {
+              case (Some(position: Position), Some(spritesheet: SpriteSheet)
+                    , Some(lo: Loot)) => 
                 (position.asJson) ~
-                  (spritesheet.asJson) ~
-                  (lo.asJson)
-              }
-              case _ => {
+                (spritesheet.asJson) ~
+                (lo.asJson)
+              case _ => 
                 log.warn("f3d3275: getComponent failed to return anything BLARG2")
                 JNothing
-              }
-            }}
+            }})        
 
-        val projectiles = world.getEntitiesWithExclusions(include = List(classOf[Projectile], classOf[Position], classOf[SpriteSheet]), exclude = List(classOf[Dead]))
+        val projectiles = world.getEntitiesWithExclusions(include=List(classOf[Projectile], classOf[Position], classOf[SpriteSheet]),
+                                                  exclude=List(classOf[Dead]))
 
-        projectilesJSON = "projs" -> projectiles.map{ projectile =>
-          (projectile.getComponent[Projectile],
-            projectile.getComponent[Position],
-            projectile.getComponent[SpriteSheet]) match {
-              case (Some(projectileComponent), Some(position), Some(spritesheet)) =>
+        projectilesJSON = ("projs" -> projectiles.map{ projectile =>
+          (projectile.getComponent(classOf[Projectile]),
+            projectile.getComponent(classOf[Position]),
+            projectile.getComponent(classOf[SpriteSheet])) match {
+              case (Some(projectileComponent: Projectile),
+                    Some(position: Position),
+                    Some(spritesheet: SpriteSheet)) =>
                 ((projectileComponent.asJson) ~
                   (position.asJson) ~
                   (spritesheet.asJson))
-              case _ => {
+              case _ =>
                 log.warn("f3d3275: getComponent failed to return anything BLARG2")
                 JNothing
-              }
-            }}
+            }})
             // println(compact(render(npcJSON)))
         try {
            roomJSON = jsonLift
@@ -144,25 +145,24 @@ class GameStateSerializer(world: World) extends Actor {
   }
 
   def getCharacterAssets(entity: Entity): JObject = {
-    val jsonLift = (entity.getComponent[Inventory],
-      entity.getComponent[Equipment],
-      entity.getComponent[QuestBag],
-      entity.getComponent[Loot],
-      entity.getComponent[Stats]) match {
-        case (Some(inventory), Some(equipment), Some(quests), None, Some(stats)) => {
+    val jsonLift = (entity.getComponent(classOf[Inventory]),
+      entity.getComponent(classOf[Equipment]),
+      entity.getComponent(classOf[QuestBag]),
+      entity.getComponent(classOf[Loot]),
+      entity.getComponent(classOf[Stats])) match {
+        case (Some(inventory: Inventory), Some(equipment: Equipment),
+              Some(quests: QuestBag), None, Some(stats: Stats)) =>
           (inventory.asJson) ~
-            (equipment.asJson) ~
-            (quests.asJson) ~
-            (stats.asJson)
-        }
-        case (Some(inventory), None, None, Some(loot), None) => {
+          (equipment.asJson) ~
+          (quests.asJson) ~
+          (stats.asJson)
+        case (Some(inventory: Inventory), None, None, Some(loot: Loot), None) =>
           (inventory.asJson) ~
-            (loot.asJson)
-        }
+          (loot.asJson)
         case _ => JNothing
       }
-
     ("models" -> jsonLift)
+
   }
 
   // TODO

--- a/src/main/scala/ayai/networking/SockoServer.scala
+++ b/src/main/scala/ayai/networking/SockoServer.scala
@@ -16,14 +16,13 @@ import org.mashupbots.socko.webserver.WebServerConfig
 import akka.actor.ActorSystem
 import akka.pattern.ask
 
-import scala.concurrent.{ExecutionContext, Await}
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Await
 import scala.concurrent.duration._
 
 /** SockoServer
  * Runs a server which will pass packets on to the Interpreter
  **/
-
-import ExecutionContext.Implicits.global
 
 object SockoServer {
   def apply(actorSystem: ActorSystem) = new SockoServer(actorSystem)

--- a/src/main/scala/ayai/networking/chat/ChatReceiver.scala
+++ b/src/main/scala/ayai/networking/chat/ChatReceiver.scala
@@ -78,7 +78,7 @@ class ChatReceiver extends Actor {
       case PublicChat(text, sender) =>
         val entities = world.getEntitiesByComponents(classOf[NetworkingActor])
         entities.foreach{ e =>  
-          (e.getComponent[NetworkingActor]: @unchecked) match {
+          (e.getComponent(classOf[NetworkingActor]): @unchecked) match {
             case(Some(na: NetworkingActor)) =>
               na.actor! new ConnectionWrite(new JChat(sender.name, text).toString)
           }

--- a/src/main/scala/ayai/persistence/CharacterTable.scala
+++ b/src/main/scala/ayai/persistence/CharacterTable.scala
@@ -82,15 +82,15 @@ object CharacterTable {
     }
   }
 
-  def saveCharacter(entity: Entity): Unit = {
-  (entity.getComponent[Position],
-    entity.getComponent[Character],
-    entity.getComponent[Room],
-    entity.getComponent[Experience]) match {
-      case(Some(position), Some(character), Some(room), Some(experience)) => {
+  def saveCharacter(entity: Entity) = {
+  (entity.getComponent(classOf[Position]),
+    entity.getComponent(classOf[Character]),
+    entity.getComponent(classOf[Room]),
+    entity.getComponent(classOf[Experience])) match {
+      case(Some(position : Position), Some(character : Character), Some(room : Room), Some(experience: Experience)) => {
         Class.forName("org.h2.Driver")
-        SessionFactory.concreteFactory = Some(() =>
-          Session.create(
+        SessionFactory.concreteFactory = Some (() =>
+            Session.create(
             java.sql.DriverManager.getConnection("jdbc:h2:ayai"),
             new H2Adapter))
 

--- a/src/main/scala/ayai/persistence/InventoryTable.scala
+++ b/src/main/scala/ayai/persistence/InventoryTable.scala
@@ -25,7 +25,7 @@ object InventoryTable {
 
   //returns a list of item ids which are in the character's id
   def getInventory(characterEntity: Entity): List[Long] = {
-    characterEntity.getComponent[Character] match {
+    characterEntity.getComponent(classOf[Character]) match {
       case Some(character: Character) =>
         Class.forName("org.h2.Driver");
         SessionFactory.concreteFactory = Some (() =>
@@ -53,7 +53,7 @@ object InventoryTable {
 
   //returns a map of slots to item ids
   def getEquipment(characterEntity: Entity): Map[String, Long] = {
-    characterEntity.getComponent[Character] match {
+    characterEntity.getComponent(classOf[Character]) match {
       case Some(character: Character) =>
         Class.forName("org.h2.Driver");
         SessionFactory.concreteFactory = Some (() =>
@@ -86,7 +86,7 @@ object InventoryTable {
   //This is so it can be done multiple times within a single transaction.
   //Deletes all copies of the item in the character's inventory
   def deleteAllOfItem(item: Item, characterEntity: Entity) {
-    characterEntity.getComponent[Character] match {
+    characterEntity.getComponent(classOf[Character]) match {
       case Some(character: Character) =>
         val characterQuery =
           from(AyaiDB.characters)(row =>
@@ -120,7 +120,7 @@ object InventoryTable {
   //MUST BE CALLED FROM WITHIN TRANSACTION
   //This is so it can be done multiple times within a single transaction.
   def decrementItem(item: Item, characterEntity: Entity) {
-    characterEntity.getComponent[Character] match {
+    characterEntity.getComponent(classOf[Character]) match {
       case Some(character: Character) =>
         val characterQuery =
             from(AyaiDB.characters)(row =>
@@ -160,9 +160,9 @@ object InventoryTable {
   //Deletes all item rows for the character out of both InventoryTable and EquipmentTable.
   //Then saves all items from Inventory to InventoryTable and Equipment to EquipmentTable.
   def saveInventory(entity: Entity) {
-    (entity.getComponent[Inventory],
-      entity.getComponent[Character],
-      entity.getComponent[Equipment]) match {
+    (entity.getComponent(classOf[Inventory]),
+      entity.getComponent(classOf[Character]),
+      entity.getComponent(classOf[Equipment])) match {
       case (Some(inventory: Inventory), Some(character: Character), Some(equipment: Equipment)) =>
         CharacterTable.getCharacter(character.name) match {
           case Some(characterRow: CharacterRow) =>
@@ -230,9 +230,9 @@ object InventoryTable {
   //  If it does exist it will increment the quantity field by the quantity parameter.
   //Don't use this in a loop. Each call will be a seperate transaction.
   def incrementItemMultiple(item: Item, characterEntity: Entity, quantity: Int) {
-    characterEntity.getComponent[Character] match {
+    characterEntity.getComponent(classOf[Character]) match {
       case Some(character : Character) =>
-        Class.forName("org.h2.Driver")
+        Class.forName("org.h2.Driver");
         SessionFactory.concreteFactory = Some (() =>
             Session.create(
             java.sql.DriverManager.getConnection("jdbc:h2:ayai"),

--- a/src/main/scala/ayai/systems/AttackSystem.scala
+++ b/src/main/scala/ayai/systems/AttackSystem.scala
@@ -18,18 +18,18 @@ object AttackSystem {
 ** Will process all Attack components and will run damage functions on all attacked victims
 ** Does not attack members of own faction
 **/
-class AttackSystem(actorSystem: ActorSystem) extends EntityProcessingSystem(include = List(classOf[Attack])) {
+class AttackSystem(actorSystem: ActorSystem) extends EntityProcessingSystem(include=List(classOf[Attack])) {
   def processEntity(e: Entity, deltaTime: Int) {
-    e.getComponent[Attack] match {
+    e.getComponent(classOf[Attack]) match {
       case Some(attack: Attack) =>
       if (!attack.victims.isEmpty) {
         for(victim <- attack.victims) {
-          if (!attack.attacked.contains(victim)) {
-            val victimFaction = victim.getComponent[Faction] match {
+          if(!attack.attacked.contains(victim)) {
+            val victimFaction = victim.getComponent(classOf[Faction]) match {
               case Some(faction: Faction) => faction.name
               case _ => ""
             }
-            val initiatorFaction = attack.initiator.getComponent[Faction] match {
+            val initiatorFaction = attack.initiator.getComponent(classOf[Faction]) match {
               case Some(faction: Faction) => faction.name
               case _ => ""
             }
@@ -52,7 +52,7 @@ class AttackSystem(actorSystem: ActorSystem) extends EntityProcessingSystem(incl
   def getWeaponStat(entity: Entity): Int = {
     var playerBase: Int = 5
     var weaponValue: Int = 5
-    entity.getComponent[Stats] match {
+    entity.getComponent(classOf[Stats]) match {
       case Some(stats: Stats) =>
         for(stat <- stats.stats) {
           if (stat.attributeType == "strength"){
@@ -61,7 +61,7 @@ class AttackSystem(actorSystem: ActorSystem) extends EntityProcessingSystem(incl
         }
       case _ =>
     }
-    entity.getComponent[Equipment] match {
+    entity.getComponent(classOf[Equipment]) match {
       case Some(equipment: Equipment) =>
           equipment.equipmentMap("weapon1").itemType match {
             case weapon: Weapon =>
@@ -87,7 +87,7 @@ class AttackSystem(actorSystem: ActorSystem) extends EntityProcessingSystem(incl
   def getArmorStat(entity: Entity) : Int = {
     var playerBase : Int = 0
     var armorValue : Int = 0
-    entity.getComponent[Stats] match {
+    entity.getComponent(classOf[Stats]) match {
       case Some(stats : Stats) =>
         for(stat <- stats.stats) {
           if (stat.attributeType == "defense"){
@@ -109,17 +109,17 @@ class AttackSystem(actorSystem: ActorSystem) extends EntityProcessingSystem(incl
     // calculate the attack
     var damage : Int = getWeaponStat(initiator)
     damage -= getArmorStat(victim)
-    val healthComponent = victim.getComponent[Health] match {
+    val healthComponent = victim.getComponent(classOf[Health]) match {
       case Some(health : Health) => health
       case _ => null
     }
     // remove the attack component of entity A
     var damageDone = handleAttackDamage(damage, healthComponent)
-    val initiatorId = initiator.getComponent[Character] match {
+    val initiatorId = initiator.getComponent(classOf[Character]) match {
       case Some(character : Character) =>
         character.id
     }
-    val victimId = victim.getComponent[Character] match {
+    val victimId = victim.getComponent(classOf[Character]) match {
       case Some(character : Character) => character.id
     }
 
@@ -137,7 +137,7 @@ class AttackSystem(actorSystem: ActorSystem) extends EntityProcessingSystem(incl
     actorSelection = actorSystem.actorSelection("user/SockoSender*")
     actorSelection ! new ConnectionWrite(compact(render(attackChat)))
 
-    var victimPosition = victim.getComponent[Position] match {
+    var victimPosition = victim.getComponent(classOf[Position]) match {
       case Some(position: Position) => position
       case _ => new Position(100,100)
     }
@@ -145,14 +145,14 @@ class AttackSystem(actorSystem: ActorSystem) extends EntityProcessingSystem(incl
     if (healthComponent.currentHealth <= 0) {
       victim.components += new Time(1000, System.currentTimeMillis())
       victim.components += new Dead()
-      // get experience and add that to the initiator's experience
-      (initiator.getComponent[Experience],
-        victim.getComponent[Experience],
-        initiator.getComponent[NPC],
-        victim.getComponent[NPC]) match {
-        case (Some(initiatorExperience: Experience), Some(victimExperience: Experience), None, Some(npc: NPC)) => 
+      // get experience and add that to the initiators experience
+      (initiator.getComponent(classOf[Experience]),
+        victim.getComponent(classOf[Experience]),
+        initiator.getComponent(classOf[NPC]),
+        victim.getComponent(classOf[NPC])) match {
+        case (Some(initiatorExperience: Experience), Some(victimExperience: Experience), None, Some(npc: NPC)) =>
           initiatorExperience.baseExperience += victimExperience.baseExperience
-          initiator.getComponent[NetworkingActor] match {
+          initiator.getComponent(classOf[NetworkingActor]) match {
             case Some(na: NetworkingActor) => 
               val att = ("type" -> "experience") ~
                         ("earned" -> victimExperience.baseExperience) 

--- a/src/main/scala/ayai/systems/CollisionSystem.scala
+++ b/src/main/scala/ayai/systems/CollisionSystem.scala
@@ -44,12 +44,12 @@ class CollisionSystem(actorSystem: ActorSystem) extends System {
   ** Then add that victim to the attacks victim array
   **/
   def handleAttack(entityA: Entity, entityB: Entity):Boolean = {
-    (entityA.getComponent[Attack],
-      entityB.getComponent[Attack],
-      entityA.getComponent[Frame],
-      entityB.getComponent[Frame],
-      entityA.getComponent[Health],
-      entityB.getComponent[Health]) match {
+    (entityA.getComponent(classOf[Attack]),
+      entityB.getComponent(classOf[Attack]),
+      entityA.getComponent(classOf[Frame]),
+      entityB.getComponent(classOf[Frame]),
+      entityA.getComponent(classOf[Health]),
+      entityB.getComponent(classOf[Health])) match {
       case(Some(attackComponentA: Attack), None, Some(frameComponentA: Frame), None, None, Some(healthComponentB: Health)) =>
           if (attackComponentA.initiator != entityB) {
             attackComponentA.addVictim(entityB)
@@ -74,10 +74,10 @@ class CollisionSystem(actorSystem: ActorSystem) extends System {
 
 
   def handleCollision(entityA: Entity, entityB: Entity) {
-      (entityA.getComponent[Position],
-        entityA.getComponent[Bounds],
-        entityB.getComponent[Position],
-        entityB.getComponent[Bounds]) match {
+      (entityA.getComponent(classOf[Position]),
+        entityA.getComponent(classOf[Bounds]),
+        entityB.getComponent(classOf[Position]),
+        entityB.getComponent(classOf[Bounds])) match {
         case(Some(positionA: Position), Some(boundsA: Bounds), Some(positionB: Position), Some(boundsB: Bounds)) =>
           // Remember to end a line with an operator of some sort (., +, &&, ||) if you need
           // to not fall afoul of the automatic end of statement guesser
@@ -120,10 +120,10 @@ class CollisionSystem(actorSystem: ActorSystem) extends System {
 
   override def process(delta: Int) {
     // get all entities that are not dead or in respawn, but do have a position and bounds
-    val entities = world.getEntitiesWithExclusions(include = List(classOf[Position], classOf[Bounds]),
-                                                   exclude = List(classOf[Respawn], classOf[Transport], classOf[Dead]))
-    val tileMap = world.asInstanceOf[RoomWorld].tileMap
-    val quadTree: QuadTree = new QuadTree(0, new Rectangle(0,0,tileMap.maximumWidth, tileMap.maximumHeight))
+    var entities = world.getEntitiesWithExclusions(include=List(classOf[Position], classOf[Bounds]),
+                                                   exclude=List(classOf[Respawn], classOf[Transport], classOf[Dead]))
+    var tileMap = world.asInstanceOf[RoomWorld].tileMap
+    var quadTree: QuadTree = new QuadTree(0, new Rectangle(0,0,tileMap.maximumWidth, tileMap.maximumHeight))
     for(entity <- entities) {
       quadTree.insert(entity)
     }

--- a/src/main/scala/ayai/systems/CooldownSystem.scala
+++ b/src/main/scala/ayai/systems/CooldownSystem.scala
@@ -12,12 +12,12 @@ object CooldownSystem {
 ** If Cooldown components are ready to be removed then remove them from the entity
 **/
 class CooldownSystem(actorSystem: ActorSystem) extends EntityProcessingSystem(include=List(classOf[Cooldown])) {
-  def processEntity(e: Entity, deltaTime: Int) {
-    e.getComponent[Cooldown] match {
-      case Some(cooldown: Cooldown) =>
-      if (cooldown.isReady) {
-        e.removeComponent[Cooldown]
-      }
-    }
-  }
+	def processEntity(e: Entity, deltaTime: Int) {
+		e.getComponent(classOf[Cooldown]) match {
+			case Some(cooldown: Cooldown) =>
+			if(cooldown.isReady) {
+				e.removeComponent(classOf[Cooldown])
+			}
+		}
+	}
 }

--- a/src/main/scala/ayai/systems/FrameExpirationSystem.scala
+++ b/src/main/scala/ayai/systems/FrameExpirationSystem.scala
@@ -22,10 +22,10 @@ object FrameExpirationSystem {
 **/
 class FrameExpirationSystem(actorSystem: ActorSystem) extends EntityProcessingSystem(include=List(classOf[Frame])) {
   def processEntity(e: Entity, deltaTime: Int) {
-    e.getComponent[Frame] match {
+    e.getComponent(classOf[Frame]) match {
       case Some(frame: Frame) => {
-        if (frame.isReady) {
-          e.getComponent[Projectile] match {
+        if(frame.isReady) {
+          e.getComponent(classOf[Projectile]) match {
             case Some(projectile: Projectile) => {
               val json = ("type" -> "disconnect") ~
                           ("id" -> projectile.id)

--- a/src/main/scala/ayai/systems/HealthSystem.scala
+++ b/src/main/scala/ayai/systems/HealthSystem.scala
@@ -18,11 +18,11 @@ object HealthSystem {
 class HealthSystem() extends EntityProcessingSystem(include=List(classOf[Health], classOf[Character]), 
                                                     exclude=List(classOf[Respawn])) {
   override def processEntity(e: Entity, deltaTime: Int) {
-    val character = (e.getComponent[Character]: @unchecked) match {
+    val character = (e.getComponent(classOf[Character]): @unchecked) match {
       case(Some(c: Character)) => c
     }
-    val health = (e.getComponent[Health]: @unchecked) match {
-      case Some(h: Health) => h
+    val health = (e.getComponent(classOf[Health]): @unchecked) match {
+      case(Some(h: Health)) => h
     }
     //look at the status effects of the character
 
@@ -30,7 +30,7 @@ class HealthSystem() extends EntityProcessingSystem(include=List(classOf[Health]
       health.currentCached = health.maxCached
     }
 
-    if (health.getCurrentValue <= 0) {
+    if(health.getCurrentValue <= 0) {
       println("dead :D")
       //attach respawn to entity
       e.components += new Dead()

--- a/src/main/scala/ayai/systems/ItemSystem.scala
+++ b/src/main/scala/ayai/systems/ItemSystem.scala
@@ -11,9 +11,9 @@ object ItemSystem {
 class ItemSystem() extends EntityProcessingSystem(include=List(classOf[ItemUse])) {
   def processEntity(entity: Entity, deltaTime: Int) {
     // what this will do is check the ItemUse initiatior and check if the Item is in the inventory and if so remove one quantity of it
-    entity.getComponent[ItemUse] match {
+    entity.getComponent(classOf[ItemUse]) match {
       case Some(itemuse: ItemUse) =>
-        itemuse.initiator.getComponent[Inventory] match {
+        itemuse.initiator.getComponent(classOf[Inventory]) match {
           case Some(inventory: Inventory) => 
             inventory.removeItem(itemuse.item)
             for(effect <- itemuse.getItemEffects()) {
@@ -33,29 +33,29 @@ class ItemSystem() extends EntityProcessingSystem(include=List(classOf[ItemUse])
   def addEffect(entity: Entity, effect: Effect) {
     effect.effectType match {
       case "currentHealth" | "maxHealth" =>
-        entity.getComponent[Health] match {
+        entity.getComponent(classOf[Health]) match {
           case Some(health: Health) => 
             println("effecting health")
             health.addEffect(effect)
           case _ => 
         }
       case "currentMana" | "maxMana" =>
-        entity.getComponent[Mana] match {
+        entity.getComponent(classOf[Mana]) match {
           case Some(mana: Mana) => mana.addEffect(effect)
           case _ => 
         }
       case "experience" =>
-        entity.getComponent[Experience] match {
+        entity.getComponent(classOf[Experience]) match {
           case Some(experience: Experience) => experience.addEffect(effect)
           case _ => 
         }
       case "velocity" =>
-        entity.getComponent[Velocity] match {
+        entity.getComponent(classOf[Velocity]) match {
           case Some(velocity: Velocity) => velocity.addEffect(effect)
           case _ =>
         }
       case "strength" | "intelligence" | "defense" =>
-        entity.getComponent[Stats] match {
+        entity.getComponent(classOf[Stats]) match {
           case Some(stats: Stats) => stats.addEffect(effect)
           case _ => 
         }

--- a/src/main/scala/ayai/systems/LevelingSystem.scala
+++ b/src/main/scala/ayai/systems/LevelingSystem.scala
@@ -18,18 +18,18 @@ class LevelingSystem(actorSystem: ActorSystem) extends EntityProcessingSystem(in
                                                                                            classOf[Character],
                                                                                            classOf[NetworkingActor])) {
   def processEntity(entity: Entity, deltaTime: Int) {
-    (entity.getComponent[Experience], entity.getComponent[Character], entity.getComponent[NetworkingActor]) match {
+    (entity.getComponent(classOf[Experience]), entity.getComponent(classOf[Character]), entity.getComponent(classOf[NetworkingActor])) match {
       case (Some(experience: Experience), Some(character: Character), Some(na: NetworkingActor)) => {
         val expThresh = Constants.EXPERIENCE_ARRAY(experience.level - 1)
         val leveledUp = experience.levelUp(expThresh)
 
         if (leveledUp) {
-          entity.getComponent[Stats] match {
+          entity.getComponent(classOf[Stats]) match {
             case Some(stats: Stats) => stats.levelUp()
             case _ =>
           }
 
-          (entity.getComponent[Health], entity.getComponent[Mana]) match {
+          (entity.getComponent(classOf[Health]), entity.getComponent(classOf[Mana])) match {
             case (Some(health: Health), Some(mana: Mana)) => {
               health.levelUp()
               mana.levelUp()

--- a/src/main/scala/ayai/systems/MovementSystem.scala
+++ b/src/main/scala/ayai/systems/MovementSystem.scala
@@ -33,10 +33,10 @@ class MovementSystem extends EntityProcessingSystem(include=List(classOf[Positio
 
   //this will only move characters who have received a movement key and the current component is still set to True
   override def processEntity(e: Entity, delta: Int) {
-  (e.getComponent[Actionable],
-    e.getComponent[Position],
-    e.getComponent[Velocity],
-    e.getComponent[Bounds]) match {
+  (e.getComponent(classOf[Actionable]),
+    e.getComponent(classOf[Position]),
+    e.getComponent(classOf[Velocity]),
+    e.getComponent(classOf[Bounds])) match {
       case (Some(actionable: Actionable), Some(position: Position), Some(velocity: Velocity), Some(bounds: Bounds)) => {
         val originalPosition = new Position(position.x, position.y)
         //if moving then process for the given direction

--- a/src/main/scala/ayai/systems/NPCRespawningSystem.scala
+++ b/src/main/scala/ayai/systems/NPCRespawningSystem.scala
@@ -11,27 +11,28 @@ object NPCRespawningSystem {
 ** And needs to be removed from the world
 **/
 class NPCRespawningSystem() extends EntityProcessingSystem(include=List(classOf[Time], classOf[Dead], classOf[NPC])) {
-  // if npc is dead then respawn them
-  def processEntity(entity: Entity, deltaTime:Int) {
-    val isRespawnable = entity.getComponent[Respawnable] match {
-      case Some(r: Respawnable) => true
-      case _ => 
-      entity.kill
-      false
-    }
-    
-    entity.getComponent[Time] match {
-      case Some(time: Time) =>
-        // println("CurrentTime: " + System.currentTimeMillis + " StartedTime: " + time.startTime + " MSActive: " + time.msActive)
-        if (time.isReady(System.currentTimeMillis)) {
-          entity.removeComponent[Dead]
-          entity.removeComponent[Time]
-          //if entity has health then refill
-          entity.getComponent[Health] match {
-            case Some(health: Health) => health.refill()
-            case _ => 
-          }
-        } 
-    }
-  }
+	// if npc is dead then respawn them
+	def processEntity(entity: Entity, deltaTime:Int) {
+		val isRespawnable = entity.getComponent(classOf[Respawnable]) match {
+			case Some(r: Respawnable) => true
+			case _ => 
+			entity.kill
+			false
+		}
+		
+		entity.getComponent(classOf[Time]) match {
+			case Some(time: Time) =>
+				// println("CurrentTime: " + System.currentTimeMillis + " StartedTime: " + time.startTime + " MSActive: " + time.msActive)
+				if(time.isReady(System.currentTimeMillis)) {
+					entity.removeComponent(classOf[Dead])
+					entity.removeComponent(classOf[Time])
+					//if entity has health then refill
+					entity.getComponent(classOf[Health]) match {
+						case Some(health: Health) => health.refill()
+						case _ => 
+					}
+				} 
+		}
+
+	}
 }

--- a/src/main/scala/ayai/systems/NetworkingSystem.scala
+++ b/src/main/scala/ayai/systems/NetworkingSystem.scala
@@ -39,7 +39,7 @@ class NetworkingSystem(networkSystem: ActorSystem) extends TimedSystem(1000/30) 
     val entities = world.getEntitiesByComponents(classOf[Character], classOf[NetworkingActor])
 
     for(characterEntity <- entities) {
-      val characterId = characterEntity.getComponent[Character] match {
+      val characterId = characterEntity.getComponent(classOf[Character]) match {
         case Some(c: Character) => c.id
         case _ =>
           log.warn("8192c19: getComponent failed to return anything")
@@ -49,7 +49,7 @@ class NetworkingSystem(networkSystem: ActorSystem) extends TimedSystem(1000/30) 
       //This is how we get character specific info, once we actually integrate this in.
       val future = serializer ? GetRoomJson(characterEntity)
       val result = Await.result(future, timeout.duration).asInstanceOf[String]
-      characterEntity.getComponent[NetworkingActor] match {
+      characterEntity.getComponent(classOf[NetworkingActor]) match {
         case Some(na : NetworkingActor) => na.actor ! new ConnectionWrite(result)
         case _ =>
       }

--- a/src/main/scala/ayai/systems/RespawningSystem.scala
+++ b/src/main/scala/ayai/systems/RespawningSystem.scala
@@ -16,26 +16,26 @@ object RespawningSystem {
 
 class RespawningSystem(actorSystem: ActorSystem) extends EntityProcessingSystem(include=List(classOf[Room], classOf[Character], classOf[Respawn], classOf[NetworkingActor])) {
   override def processEntity(e: Entity, delta: Int) {
-    val respawn = (e.getComponent[Respawn]: @unchecked) match {
+    val respawn = (e.getComponent(classOf[Respawn]): @unchecked) match {
       case (Some(r: Respawn)) => r
       case _ => null
     }
-    val health = (e.getComponent[Health]: @unchecked) match {
+    val health = (e.getComponent(classOf[Health]): @unchecked) match {
       case (Some(h: Health)) => h
       case _ => null
     }
 
-    val position = (e.getComponent[Position]: @unchecked) match {
+    val position = (e.getComponent(classOf[Position]): @unchecked) match {
       case Some(p: Position) => p
       case _ => null
     }
 
     if (respawn.isReady(System.currentTimeMillis())) {
       health.refill()
-      e.removeComponent[Respawn]
-      e.removeComponent[Dead]
+      e.removeComponent(classOf[Respawn])
+      e.removeComponent(classOf[Dead])
     } else {
-      val na = (e.getComponent[NetworkingActor]) match {
+      val na = (e.getComponent(classOf[NetworkingActor])) match {
         case Some(networkActor: NetworkingActor) =>
           val json = ("type" -> "chat") ~
             ("message" -> ("Respawn in: " + respawn.timeLeft(System.currentTimeMillis()).toString)) ~

--- a/src/main/scala/ayai/systems/RoomChangingSystem.scala
+++ b/src/main/scala/ayai/systems/RoomChangingSystem.scala
@@ -32,14 +32,14 @@ class RoomChangingSystem(networkSystem: ActorSystem) extends EntityProcessingSys
   val userRoomMap = networkSystem.actorSelection("user/UserRoomMap")
   override def processEntity(e: Entity, delta: Int) {
     //get information from transport class
-    (e.getComponent[Transport],
-      e.getComponent[Room],
-      e.getComponent[Position]) match {
+    (e.getComponent(classOf[Transport]),
+      e.getComponent(classOf[Room]),
+      e.getComponent(classOf[Position])) match {
       case(Some(transport: Transport), Some(room: Room),
         Some(position: Position)) =>
         userRoomMap ! SwapWorld(e.tag, transport.toRoom)
         InventoryTable.saveInventory(e)
-        e.removeComponent[Transport]
+        e.removeComponent(classOf[Transport])
       case _ =>
         log.warn("052ef02: getComponent failed to return anything")
     }

--- a/src/main/scala/ayai/systems/StatusEffectSystem.scala
+++ b/src/main/scala/ayai/systems/StatusEffectSystem.scala
@@ -20,7 +20,7 @@ class StatusEffectSystem() extends EntityProcessingSystem(include = List(classOf
   implicit val timeout = Timeout(Constants.NETWORK_TIMEOUT seconds)
 
   def processEntity(e: Entity, deltaTime: Int) {
-    e.getComponent[Health] match {
+    e.getComponent(classOf[Health]) match {
       case Some(health: Health) => {
         if (health.currentModifiers.size >= 1) {
           println("Status Effecting")
@@ -30,19 +30,19 @@ class StatusEffectSystem() extends EntityProcessingSystem(include = List(classOf
       }
       case _ =>
     }
-    e.getComponent[Mana] match {
+    e.getComponent(classOf[Mana]) match {
       case Some(mana: Mana) => mana.updateCachedValue()
       case _ =>
     }
-    e.getComponent[Experience] match {
+    e.getComponent(classOf[Experience]) match {
       case Some(experience: Experience) => experience.updateCachedValue()
       case _ =>
     }
-    e.getComponent[Stats] match {
+    e.getComponent(classOf[Stats]) match {
       case Some(stats: Stats) => stats.updateCachedValue()
       case _ =>
     }
-    e.getComponent[Velocity] match {
+    e.getComponent(classOf[Velocity]) match {
       case Some(velocity: Velocity) => velocity.updateCachedValue()
       case _ =>
     }

--- a/src/main/scala/ayai/systems/TransportSystem.scala
+++ b/src/main/scala/ayai/systems/TransportSystem.scala
@@ -57,9 +57,9 @@ extends EntityProcessingSystem(include = List(classOf[Room], classOf[Position], 
   private val log = LoggerFactory.getLogger(getClass)
   //this will only move characters who have received a movement key and the current component is still set to True
   override def processEntity(e: Entity, delta : Int) {
-  (e.getComponent[Room],
-    e.getComponent[Position],
-    e.getComponent[NetworkingActor]) match {
+  (e.getComponent(classOf[Room]),
+    e.getComponent(classOf[Position]),
+    e.getComponent(classOf[NetworkingActor])) match {
       case (Some(room: Room), Some(position: Position), Some(networkingActor: NetworkingActor)) => {
         val tileMap: TileMap = world.asInstanceOf[RoomWorld].tileMap
         val transportOption: Option[TransportInfo] = tileMap.checkIfTransport(position)

--- a/src/main/scala/ayai/systems/ai/DirectorSystem.scala
+++ b/src/main/scala/ayai/systems/ai/DirectorSystem.scala
@@ -16,18 +16,21 @@ object DirectorSystem {
 class DirectorSystem(actorSystem: ActorSystem) extends TimedSystem(3000) {
   override def processTime(delta: Int) {
     val entities = world.getEntitiesByComponents(classOf[Character], classOf[Faction])
-    val factions = entities.groupBy(e => e.getComponent[Faction]).filterKeys(_.isDefined).map {
-      case (key, value) => (key.get.name, value)
-    }
+    val factions = entities.groupBy(e => (e.getComponent(classOf[Faction])) match {
+      case(Some(f: Faction)) => f.name
+      case _ => ""
+    })
 
     // Create enough entities to make it even in healthwise-ness
 
     val factionHealths = factions.map {
-      case (key, faction) => (key, faction.foldLeft(0) {
+      case(key, faction) => (key, faction.foldLeft(0){
         (x: Int, y: Entity) =>  
-          y.getComponent[Health] match {
-            case Some(yh) => x + yh.maximumHealth
-            case _ => x
+          (y.getComponent(classOf[Health])) match {
+            case Some(yh: Health) =>
+              x + yh.maximumHealth
+            case _ =>
+              x
           }
       })
     }
@@ -58,12 +61,12 @@ class DirectorSystem(actorSystem: ActorSystem) extends TimedSystem(3000) {
         case _ => i + 1
       }
 
-      val position = (factions.values.toList(otherIndex)(0).getComponent[Position]: @unchecked) match {
+      val position = factions.values.toList(otherIndex)(0).getComponent(classOf[Position]: @unchecked) match {
         case(Some(p: Position)) => p
       }
 
       faction.foreach{ entity => 
-        (entity.getComponent[Goal]: @unchecked) match {
+        (entity.getComponent(classOf[Goal]): @unchecked) match {
           case(Some(g: Goal)) => g.goal = new AttackTo(position)
           case _ => ()
         }

--- a/src/main/scala/ayai/systems/ai/GoalSystem.scala
+++ b/src/main/scala/ayai/systems/ai/GoalSystem.scala
@@ -25,7 +25,7 @@ class GoalSystem(actorSystem: ActorSystem) extends System {
   }
 
   def findDirection(entity: Entity, tp: Position): MoveDirection = {
-    (entity.getComponent[Position]: @unchecked) match {
+    (entity.getComponent(classOf[Position]): @unchecked) match {
       case Some(ep: Position) =>
         val xDistance = ep.x - tp.x
         val yDistance = ep.y - tp.y
@@ -50,7 +50,7 @@ class GoalSystem(actorSystem: ActorSystem) extends System {
   override def process(delta: Int) {
     val entities = world.getEntitiesWithExclusions(include=List(classOf[Goal], classOf[Position], classOf[Actionable], classOf[Character]), exclude=List(classOf[Dead]))
     for(entity <- entities) {
-      val goal = (entity.getComponent[Goal]: @unchecked) match {
+      val goal = (entity.getComponent(classOf[Goal]): @unchecked) match {
         case Some(g: Goal) => g.goal
       }
 
@@ -64,7 +64,7 @@ class GoalSystem(actorSystem: ActorSystem) extends System {
       }
 
       val direction = findDirection(entity, position)
-      (entity.getComponent[Actionable], entity.getComponent[Character], entity.getComponent[Position]) match {
+      (entity.getComponent(classOf[Actionable]), entity.getComponent(classOf[Character]), entity.getComponent(classOf[Position])) match {
         case (Some(actionable: Actionable), Some(character: Character), Some(ep: Position)) => {
           goal match {
             case mt: MoveTo =>
@@ -82,12 +82,12 @@ class GoalSystem(actorSystem: ActorSystem) extends System {
 
                   entity match {
                     case initiator: Entity => {
-                      (initiator.getComponent[Position],
-                      initiator.getComponent[Actionable],
-                      initiator.getComponent[Character],
-                      initiator.getComponent[Room],
-                      initiator.getComponent[Cooldown],
-                      initiator.getComponent[Dead]) match {
+                      (initiator.getComponent(classOf[Position]),
+                      initiator.getComponent(classOf[Actionable]),
+                      initiator.getComponent(classOf[Character]),
+                      initiator.getComponent(classOf[Room]),
+                      initiator.getComponent(classOf[Cooldown]),
+                      initiator.getComponent(classOf[Dead])) match {
                         case(Some(pos: Position), Some(a: Actionable), Some(c: Character), Some(r: Room), None, None) => {
 
                           val m = a.action match {
@@ -98,7 +98,7 @@ class GoalSystem(actorSystem: ActorSystem) extends System {
                           }
 
                           //get the range of the characters weapon
-                          val weaponRange = initiator.getComponent[Equipment] match {
+                          val weaponRange = initiator.getComponent(classOf[Equipment]) match {
                             case Some(e: Equipment) => e.equipmentMap("weapon1").itemType match {
                               case weapon: Weapon => weapon.range
                               case _ => 30


### PR DESCRIPTION
This reverts commit 6546da285f6372ea9502c837499d566ba2b2f50c.

Reverts 6546da2 what seem to be breaking changes from the upgrade to a newer version of Crane that I worked on with @timothyhahn. The idea in https://github.com/timothyhahn/crane/commit/f980d8d9369f6db3566ffa1818d0ff331de66f2d was to rid us from having to use `classOf[X]` everywhere and instead just query for the type itself.

The issue I was experiencing that I narrowed down to this commit was components not being transferred correctly when an entity moves between `Room`s in the game. I narrowed bug down to this commit through `git bisect`. If any of you guys want to dig into this, feel free!
