### PR TITLE
Refactor TileMap, and fix spelling and formatting in other files

### DIFF
--- a/src/main/scala/ayai/components/Perception.scala
+++ b/src/main/scala/ayai/components/Perception.scala
@@ -41,7 +41,7 @@ class LOS {
   }
 
   def isCollision(position: Position, bounds: Bounds, tileMap: TileMap): Boolean = {
-    tileMap.isPositionInBounds(position)
+    tileMap.clipPositionToBounds(position)
 
     //if on tile Collision go back to original position
     val collision = tileMap.onTileCollision(position, bounds)

--- a/src/main/scala/ayai/gamestate/MessageProcessor.scala
+++ b/src/main/scala/ayai/gamestate/MessageProcessor.scala
@@ -103,7 +103,7 @@ class MessageProcessor(world: RoomWorld) extends Actor {
               val m = a.action match {
                 case (move: MoveDirection) => move
                 case _ =>
-                  println("Not match for movedirection")
+                  println("No match for MoveDirection")
                   new MoveDirection(0, 0)
               }
 
@@ -122,8 +122,8 @@ class MessageProcessor(world: RoomWorld) extends Actor {
                 }
               }
 
-              val upperLeftx = pos.x
-              val upperLefty = pos.y
+              val upperLeftX = pos.x
+              val upperLeftY = pos.y
 
               val xDirection = m.xDirection
               val yDirection = m.yDirection
@@ -137,7 +137,7 @@ class MessageProcessor(world: RoomWorld) extends Actor {
                 p.components += new Projectile(bulletId)
                 p.components += new Velocity(Constants.PROJECTILE_VELOCITY, Constants.PROJECTILE_VELOCITY)
                 p.components += new Actionable(true, a.action)
-                p.components += new Position(upperLeftx, upperLefty)
+                p.components += new Position(upperLeftX, upperLeftY)
                 p.components += new Bounds(20, 20)
                 p.components += new Frame(weaponRange/Constants.PROJECTILE_VELOCITY)
 
@@ -145,10 +145,10 @@ class MessageProcessor(world: RoomWorld) extends Actor {
                   p.components += SpriteSheetFactory.getSpriteSheet(weaponName, xDirection, yDirection)
               }
               else { //it's melee
-                val topLeftOfAttackx = (weaponRange * xDirection) + upperLeftx
-                val topLeftOfAttacky = (weaponRange * yDirection) + upperLefty
+                val topLeftOfAttackX = (weaponRange * xDirection) + upperLeftX
+                val topLeftOfAttackY = (weaponRange * yDirection) + upperLeftY
 
-                p.components += new Position(topLeftOfAttackx, topLeftOfAttacky)
+                p.components += new Position(topLeftOfAttackX, topLeftOfAttackY)
                 p.components += new Bounds(weaponRange, weaponRange)
                 p.components += new Frame(30)
               }
@@ -243,7 +243,7 @@ class MessageProcessor(world: RoomWorld) extends Actor {
                       inventory.inventory += equippedItem
                       equipment.equipmentMap(equipmentType) = new EmptySlot(equipmentType)
                     }
-                    case _ => println(equipmentType + " not valiid")
+                    case _ => println(equipmentType + " not valid")
                   }
                 }
                 case _ => println(s"User $userId cannot equip $equipmentType.")
@@ -423,7 +423,7 @@ class MessageProcessor(world: RoomWorld) extends Actor {
 
 
           //take item and put it in player inventory
-          var itemToRemove: Item  = null
+          var itemToRemove: Item = null
           for(itemInv <- loot.inventory) {
             if (itemInv.id == itemId) {
               personInv.addItem(itemInv)

--- a/src/main/scala/ayai/gamestate/MessageProcessorSupervisor.scala
+++ b/src/main/scala/ayai/gamestate/MessageProcessorSupervisor.scala
@@ -33,7 +33,7 @@ class MessageProcessorSupervisor(world: RoomWorld) extends Actor {
 
   def receive = {
     case message: ProcessMessage => router forward message
-    case _ => println("Error: in procesor supervisor")
+    case _ => println("Error: in processor supervisor")
   }
 
 }

--- a/src/main/scala/ayai/gamestate/TileMap.scala
+++ b/src/main/scala/ayai/gamestate/TileMap.scala
@@ -22,46 +22,22 @@ class TileMap(val array: Array[Array[Tile]], var transports: List[TransportInfo]
 
   def getTileByPosition(position: Position): Tile = array(valueToTile(position.x))(valueToTile(position.y))
 
-  // Get a tile by a x or y value from the array (example: 32 tilesize value, 65 (position) / 32) = 2 tile
+  // Get a tile by a x or y value from the array (example: 32 tileSize value, 65 (position) / 32) = 2 tile
   def valueToTile(value: Int): Int = value / tileSize
 
-  def isPositionInBounds(position: Position): Position = {
-    if (max(position.x, 0) <= 0) {
-      position.x = 0
-    } else if (min(position.x, maximumWidth - tileSize) >= maximumWidth-tileSize) {
-      position.x = maximumWidth - tileSize
-    }
-
-    if (max(position.y, 0) <= 0) {
-      position.y = 0
-    } else if (min(position.y, maximumHeight) >= maximumHeight - tileSize) {
-      position.y = maximumHeight - tileSize
-    }
-
-    position
-  }
+  def clipPositionToBounds(position: Position) = Position(
+    position.x.max(0).min(maximumWidth - tileSize),
+    position.y.max(0).min(maximumHeight - tileSize)
+  )
 
   def onTileCollision(position: Position, bounds: Bounds): Boolean = {
-    val newPos = new Position(position.x + bounds.width, position.y+bounds.height)
-    val tile = getTileByPosition(isPositionInBounds(newPos))
+    val newPos = Position(position.x + bounds.width, position.y + bounds.height)
+    val tile = getTileByPosition(clipPositionToBounds(newPos))
 
-    if (tile.isCollidable) {
-      return true
-    }
-
-    if (getTileByPosition(position).isCollidable) {
-      return true
-    }
-
-    if (getTileByPosition(isPositionInBounds(new Position(position.x, position.y + bounds.height))).isCollidable){
-      return true
-    }
-
-    if (getTileByPosition(isPositionInBounds(new Position(position.x + bounds.width, position.y))).isCollidable) {
-      return true
-    }
-
-    false
+    return tile.isCollidable ||
+      getTileByPosition(position).isCollidable ||
+      getTileByPosition(clipPositionToBounds(Position(position.x + bounds.width, position.y))).isCollidable ||
+      getTileByPosition(clipPositionToBounds(Position(position.x, position.y + bounds.height))).isCollidable
   }
 
   /**
@@ -69,7 +45,7 @@ class TileMap(val array: Array[Array[Tile]], var transports: List[TransportInfo]
    * If inside transport area, then return the new transport
    */
   def checkIfTransport(characterPosition: Position): Option[TransportInfo] = {
-    for(transport <- transports) {
+    for (transport <- transports) {
       val startPosition = transport.startingPosition
       val endPosition = transport.endingPosition
 

--- a/src/main/scala/ayai/systems/MovementSystem.scala
+++ b/src/main/scala/ayai/systems/MovementSystem.scala
@@ -52,7 +52,7 @@ class MovementSystem extends EntityProcessingSystem(include=List(classOf[Positio
 
         //will update position in function
         val tileMap = world.asInstanceOf[RoomWorld].tileMap
-        tileMap.isPositionInBounds(position)
+        tileMap.clipPositionToBounds(position)
 
         //if on tile Collision go back to original position
         val collision = tileMap.onTileCollision(position, bounds)


### PR DESCRIPTION
The method `isPositionInBounds` was wrongly named – it returns a Position, not a Boolean. It also had a copy-paste error – it was missing `- tileSize` on line 37. The refactoring avoids the possibility of that problem.

I simplified `onTileCollision`’s chain of `if`s by just returning one boolean expression.

I only fixed the spelling in `println` strings. I avoided fixing the many misspellings in the same file that were in messages sent to actors, because I am guessing that the front-end looks for those exact messages.
