### PR TITLE
Fix bugs in and refactor TileMap and related

### DIFF
--- a/src/main/scala/ayai/factories/EntityFactory.scala
+++ b/src/main/scala/ayai/factories/EntityFactory.scala
@@ -143,7 +143,7 @@ object EntityFactory {
         val tileMapString = mapFile.mkString.filterNot({_ == "\n"})
         mapFile.close()
 
-        val json =("type" -> "id") ~
+        val json = ("type" -> "id") ~
           ("id" -> entityId) ~
           ("x" -> x) ~
           ("y" -> y) ~
@@ -164,7 +164,7 @@ object EntityFactory {
   }
 
   /**
-  ** Create all NPCS given in npcs.json
+  ** Create all NPCs given in npcs.json
   **/
   def createNPC(world: World, faction: String, npcValue: AllNPCValues, questBuffer: ArrayBuffer[Quest] = new ArrayBuffer[Quest]()): Entity = {
     val id = new UID().toString
@@ -322,7 +322,7 @@ object EntityFactory {
     val arrayTile: Array[Array[Tile]] = Array.fill[Tile](tmap.width, tmap.height)(new Tile(ListBuffer()))
 
 
-    //get and transorm tiles from a list to multi-dimensional array
+    //get and transform tiles from a list to multi-dimensional array
     for (i <- 0 until width * height) {
       for (bundle <- bundles) {
         if (bundle.data(i) != 0 ) {

--- a/src/main/scala/ayai/gamestate/TileMap.scala
+++ b/src/main/scala/ayai/gamestate/TileMap.scala
@@ -1,49 +1,37 @@
 package ayai.gamestate
 
-/** Ayai Imports **/
 import ayai.components._
 import ayai.maps.{Tile, Layer, TransportInfo, Tileset}
 
-/** External Imports **/
-import scala.math._
-
-//128 x 128 is only default
+// 128 x 128 is only a default
 class TileMap(val array: Array[Array[Tile]], var transports: List[TransportInfo], var tilesets: List[Tileset]) {
   var file: String = ""
   var width: Int = 128
   var height: Int = 128
   var tileSize: Int = 32
 
-  //getMaximumPosition - get the maximum position value for x
+  //get the maximum position value for x
   def maximumWidth: Int = array.length * tileSize
 
-  //getMaximumHeight - get the maximum position value for y
+  //get the maximum position value for y
   def maximumHeight: Int = array(0).length * tileSize
 
   def getTileByPosition(position: Position): Tile = array(valueToTile(position.x))(valueToTile(position.y))
 
-  // Get a tile by a x or y value from the array (example: 32 tilesize value, 65 (position) / 32) = 2 tile
+  // Get a tile by a x or y value from the array (example: 32 tileSize value, 65 (position) / 32) = 2 tile
   def valueToTile(value: Int): Int = value / tileSize
 
-  def isPositionInBounds(position: Position): Position = {
-    if (max(position.x, 0) <= 0) {
-      position.x = 0
-    } else if (min(position.x, maximumWidth - tileSize) >= maximumWidth-tileSize) {
-      position.x = maximumWidth - tileSize
-    }
-
-    if (max(position.y, 0) <= 0) {
-      position.y = 0
-    } else if (min(position.y, maximumHeight) >= maximumHeight - tileSize) {
-      position.y = maximumHeight - tileSize
-    }
-
-    position
+  def clipPositionToBounds(position: Position) {
+    val maxX = maximumWidth - tileSize
+    val maxY = maximumHeight - tileSize
+    if (position.x < 0) position.x = 0 else if (position.x > maxX) position.x = maxX
+    if (position.y < 0) position.y = 0 else if (position.y > maxY) position.y = maxY
   }
 
-  def onTileCollision(position: Position, bounds: Bounds): Boolean = {
-    val newPos = new Position(position.x + bounds.width, position.y+bounds.height)
-    val tile = getTileByPosition(isPositionInBounds(newPos))
+  def regionCollidesWithATile(position: Position, bounds: Bounds): Boolean = {
+    val newPos = new Position(position.x + bounds.width, position.y + bounds.height)
+    clipPositionToBounds(newPos)
+    val tile = getTileByPosition(newPos)
 
     if (tile.isCollidable) {
       return true
@@ -53,11 +41,15 @@ class TileMap(val array: Array[Array[Tile]], var transports: List[TransportInfo]
       return true
     }
 
-    if (getTileByPosition(isPositionInBounds(new Position(position.x, position.y + bounds.height))).isCollidable){
+    val bottomLeftPosition = new Position(position.x, position.y + bounds.height)
+    clipPositionToBounds(bottomLeftPosition)
+    if (getTileByPosition(bottomLeftPosition).isCollidable){
       return true
     }
 
-    if (getTileByPosition(isPositionInBounds(new Position(position.x + bounds.width, position.y))).isCollidable) {
+    val topRightPosition = new Position(position.x + bounds.width, position.y)
+    clipPositionToBounds(topRightPosition)
+    if (getTileByPosition(topRightPosition).isCollidable) {
       return true
     }
 
@@ -65,7 +57,7 @@ class TileMap(val array: Array[Array[Tile]], var transports: List[TransportInfo]
   }
 
   /**
-   * For checkIfTransport, use the characters position and see if they are in any of the transport areas
+   * For checkIfTransport, use the character’s position and see if they are in any of the transport areas
    * If inside transport area, then return the new transport
    */
   def checkIfTransport(characterPosition: Position): Option[TransportInfo] = {

--- a/src/main/scala/ayai/systems/MovementSystem.scala
+++ b/src/main/scala/ayai/systems/MovementSystem.scala
@@ -38,7 +38,7 @@ class MovementSystem extends EntityProcessingSystem(include=List(classOf[Positio
     e.getComponent(classOf[Velocity]),
     e.getComponent(classOf[Bounds])) match {
       case (Some(actionable: Actionable), Some(position: Position), Some(velocity: Velocity), Some(bounds: Bounds)) => {
-        val originalPosition = new Position(position.x, position.y)
+
         //if moving then process for the given direction
         if (actionable.active) {
           // if action is a direction
@@ -50,13 +50,13 @@ class MovementSystem extends EntityProcessingSystem(include=List(classOf[Positio
           }
         }
 
-        //will update position in function
+        //clipPositionToBounds will update the position
+        val originalPosition = new Position(position.x, position.y)
         val tileMap = world.asInstanceOf[RoomWorld].tileMap
-        tileMap.isPositionInBounds(position)
+        tileMap.clipPositionToBounds(position)
 
-        //if on tile Collision go back to original position
-        val collision = tileMap.onTileCollision(position, bounds)
-        if (collision) {
+        //if tile collision go back to original position
+        if (tileMap.regionCollidesWithATile(position, bounds)) {
           position.x = originalPosition.x
           position.y = originalPosition.y
         }

--- a/src/main/scala/ayai/systems/TransportSystem.scala
+++ b/src/main/scala/ayai/systems/TransportSystem.scala
@@ -56,7 +56,7 @@ extends EntityProcessingSystem(include = List(classOf[Room], classOf[Position], 
   implicit val timeout = Timeout(Constants.NETWORK_TIMEOUT seconds)
   private val log = LoggerFactory.getLogger(getClass)
   //this will only move characters who have received a movement key and the current component is still set to True
-  override def processEntity(e: Entity, delta : Int) {
+  override def processEntity(e: Entity, delta: Int) {
   (e.getComponent(classOf[Room]),
     e.getComponent(classOf[Position]),
     e.getComponent(classOf[NetworkingActor])) match {


### PR DESCRIPTION
I changed TileMap’s poorly-named `isPositionInBounds` method to `clipPositionToBounds`, making it return `Unit` to follow the principle of CQS (Command-Query Separation). I also renamed `onTileCollision` to `regionCollidesWithATile`.

I fixed a bug in `clipPositionToBounds` where the ranges were not being compared to the right number. Its use of `min` and `max` also redundantly compared the number to itself, so I removed that.

I capitalized words in the middle of variable names in Perception to make them easier to read.
